### PR TITLE
Let espeak choose the buffer size

### DIFF
--- a/espeak.c
+++ b/espeak.c
@@ -217,7 +217,7 @@ static void reinitialize_espeak(struct synth_t *s)
 	int rate;
 
 	/* Re-initialize espeak */
-	rate = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 50, NULL, 0);
+	rate = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 0, NULL, 0);
 	if (rate < 0) {
 		fprintf(stderr, "Unable to initialize espeak.\n");
 		return;
@@ -300,7 +300,7 @@ int initialize_espeak(struct synth_t *s)
 	int rate;
 
 	/* initialize espeak */
-	rate = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 50, NULL, 0);
+	rate = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 0, NULL, 0);
 	if (rate < 0) {
 		fprintf(stderr, "Unable to initialize espeak.\n");
 		return -1;


### PR DESCRIPTION
The default is already quite small, and choosing a too small one may
lead to broken speech.

Fixes #13