### PR TITLE
use correct case for --pid-file option

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -77,7 +77,7 @@ void process_cli(int argc, char **argv)
 	do {
 		opt = getopt_long(argc, argv, shortOptions, longOptions, NULL);
 		switch (opt) {
-		case 'p':
+		case 'P':
 			pidPath = dupeString(optarg);
 			break;
 		case 'V':


### PR DESCRIPTION
This permits --pid-file to be specified.
The getopt_long option was looking for a lowercase p,
and the pid-file option used an uppercase P.
This meant that pid-file was never settable.