### PR TITLE
Throttle on EE_BUFFER_FULL errors

### DIFF
--- a/src/espeakup.c
+++ b/src/espeakup.c
@@ -40,6 +40,7 @@ volatile int should_run = 1;
 espeak_AUDIO_OUTPUT audio_mode;
 
 pthread_cond_t runner_awake = PTHREAD_COND_INITIALIZER;
+pthread_cond_t wake_stop = PTHREAD_COND_INITIALIZER;
 pthread_cond_t stop_acknowledged = PTHREAD_COND_INITIALIZER;
 pthread_mutex_t queue_guard = PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/espeakup.h
+++ b/src/espeakup.h
@@ -99,6 +99,7 @@ extern int self_pipe_fds[2];
 #define PIPE_WRITE_FD (self_pipe_fds[1])
 
 extern pthread_cond_t runner_awake;
+extern pthread_cond_t wake_stop;
 extern pthread_cond_t stop_acknowledged;
 extern pthread_mutex_t queue_guard;
 

--- a/src/softsynth.c
+++ b/src/softsynth.c
@@ -228,6 +228,7 @@ static void request_espeak_stop(void)
 	pthread_mutex_lock(&queue_guard);
 	stop_requested = 1;
 	pthread_cond_signal(&runner_awake);     // Wake runner, if necessary.
+	pthread_cond_signal(&wake_stop);        // Wake runner, if necessary.
 	while (should_run && stop_requested)
 		// wait for acknowledgement.
 		pthread_cond_wait(&stop_acknowledged, &queue_guard);


### PR DESCRIPTION
When espeak returns EE_BUFFER_FULL we should just wait a bit before
retrying. Also, we don't want to lose the current entry. We however want
to wake up as soon as possible on stop request.