### PR TITLE
queue_process_entry: Avoid leaving error uninitialized

### DIFF
--- a/src/espeak.c
+++ b/src/espeak.c
@@ -377,12 +377,18 @@ static void queue_process_entry(struct synth_t *s)
 		break;
 	case CMD_PAUSE:
 		if (!paused_espeak) {
-			espeak_Cancel();
-			espeak_Terminate();
-			paused_espeak = 1;
+			error = espeak_Cancel();
+			if (error == EE_OK)
+				error = espeak_Terminate();
+			if (error == EE_OK)
+				paused_espeak = 1;
+		} else {
+			error = EE_OK;
 		}
 		break;
 	default:
+		/* Uh? */
+		error = EE_OK;
 		break;
 	}
 


### PR DESCRIPTION
CMD_PAUSE was not actually setting error to EE_OK, and the default case,
even if it is not supposed to happen, should set error to something sane.