### PR TITLE
Add --volume option

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -35,11 +35,15 @@ extern char *defaultVoice;
 /* Whether to drive ALSA volume */
 extern int alsaVolume;
 
+/* default volume */
+extern int defaultVolume;
+extern int volumeSet;
 /* command line options */
 const char *shortOptions = "P:V:adhv";
 const struct option longOptions[] = {
 	{"pid-path", required_argument, NULL, 'P'},
 	{"default-voice", required_argument, NULL, 'V'},
+	{"volume", required_argument, NULL, 'x'},
 	{"alsa-volume", no_argument, &alsaVolume, 1},
 	{"acsint", no_argument, NULL, 'a'},
 	{"debug", no_argument, NULL, 'd'},
@@ -57,6 +61,7 @@ static void show_help()
 	printf("  --debug, -d\t\t\t\tDebug mode (stay in the foreground).\n");
 	printf("  --help, -h\t\t\t\tShow this help.\n");
 	printf("  --version, -v\t\t\t\tDisplay the software version.\n");
+	printf("  --volume=[1-150]\t\t\tSet the volume of speakup.\n");
 	exit(0);
 }
 
@@ -94,6 +99,14 @@ void process_cli(int argc, char **argv)
 			break;
 		case 'v':
 			show_version();
+			break;
+		case 'x':
+			volumeSet = 1;
+			defaultVolume = atoi(optarg);
+			if (defaultVolume < 1 || defaultVolume > 150) {
+				fprintf(stderr, "WARNING: Volume must be between 1 and 150\n");
+				volumeSet = 0;
+			}
 			break;
 		case -1:
 		case 0:

--- a/src/cli.c
+++ b/src/cli.c
@@ -37,7 +37,9 @@ extern int alsaVolume;
 
 /* default volume */
 extern int defaultVolume;
-extern int volumeSet;
+extern int volumeOffset;
+extern int alsaVolumeOffset;
+extern int volumeMultiplier;
 /* command line options */
 const char *shortOptions = "P:V:adhv";
 const struct option longOptions[] = {
@@ -101,13 +103,14 @@ void process_cli(int argc, char **argv)
 			show_version();
 			break;
 		case 'x':
-			volumeSet = 1;
-			defaultVolume = atoi(optarg);
-			if (defaultVolume < 1 || defaultVolume > 150) {
+			alsaVolumeOffset = volumeOffset = atoi(optarg);
+			if (volumeOffset < 1 || volumeOffset > 150) {
 				fprintf(stderr, "WARNING: Volume must be between 1 and 150\n");
-				volumeSet = 0;
+				volumeOffset = 0;
 			}
-			break;
+                        alsaVolumeOffset -= (defaultVolume + 1) * 50 / 10 + 50;
+                        volumeOffset -= (defaultVolume + 1) * volumeMultiplier;
+                        break;
 		case -1:
 		case 0:
 			break;

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -204,6 +204,10 @@ static void set_alsa_volume(int vol)
 	 * 100%. */
 
 	int volume = (vol + 1) * 50 / 10 + 50;
+	/*lock the volume to the user-set volume if specified*/
+	if(volumeSet){
+		volume = defaultVolume;
+	}
 
 	for (e = snd_mixer_first_elem(m); e; e = snd_mixer_elem_next(e)) {
 		if (snd_mixer_elem_get_type(e) != SND_MIXER_ELEM_SIMPLE)
@@ -253,7 +257,7 @@ static espeak_ERROR set_volume(struct synth_t *s, int vol, enum adjust_t adj)
 	if (adj != ADJ_SET)
 		vol += s->volume;
 
-	/* use the volume if specified by the user */
+	/*lock the volume to the user-set volume if specified*/
 	if (volumeSet) {
 		rc = espeak_SetParameter(espeakVOLUME, defaultVolume, 0);
 	}

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -32,7 +32,8 @@ const int defaultFrequency = 5;
 const int defaultPitch = 5;
 const int defaultRange = 5;
 const int defaultRate = 2;
-const int defaultVolume = 5;
+int defaultVolume = 5;
+int volumeSet = 0;
 char *defaultVoice = NULL;
 int alsaVolume = 0;
 
@@ -42,7 +43,7 @@ const int pitchMultiplier = 11;
 const int rangeMultiplier = 11;
 const int rateMultiplier = 41;
 const int rateOffset = 80;
-const int volumeMultiplier = 22;
+const int volumeMultiplier = 16;
 
 volatile int stop_requested = 0;
 int paused_espeak = 1;
@@ -246,11 +247,19 @@ static espeak_ERROR set_volume(struct synth_t *s, int vol, enum adjust_t adj)
 {
 	espeak_ERROR rc;
 
+
 	if (adj == ADJ_DEC)
 		vol = -vol;
 	if (adj != ADJ_SET)
 		vol += s->volume;
-	rc = espeak_SetParameter(espeakVOLUME, (vol + 1) * volumeMultiplier, 0);
+
+	/* use the volume if specified by the user */
+	if (volumeSet) {
+		rc = espeak_SetParameter(espeakVOLUME, defaultVolume, 0);
+	}
+	else {
+		rc = espeak_SetParameter(espeakVOLUME, (vol + 1) * volumeMultiplier, 0);
+	}
 	if (rc == EE_OK) {
 		s->volume = vol;
 		if (alsaVolume)


### PR DESCRIPTION
 Add --volume=N command line argument to set volume

 I ran into a situation where espeakup was far too loud on my system, and I couldn’t find a built-in way to adjust the volume. This patch adds a --volume=N option so that users can configure the volume when they start espeakup.

Most users will likely edit the volume with alsa, but this can be useful for cases where the user can't find an easy way to change the volume. One example is my case, where the amixer control to change the volume isn't something standard or easy to guess, such as in my case where the proper control name is "PGA1.0 1 Master", which is something I couldn't have reasonably found without being able to plug in a monitor and scroll through all the options in alsamixer