### PR TITLE
meson: replace deprecated get_pkgconfig_variable and require Meson >= 0.51

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project('espeakup', 'c',
     ],
   license : 'GPL-3.0-or-later',
   version : '0.90',
-  meson_version : '>=0.47.0')
+  meson_version : '>=0.51.0')
 
 cc = meson.get_compiler('c')
 thread_dep = dependency('threads')

--- a/services/systemd/meson.build
+++ b/services/systemd/meson.build
@@ -1,4 +1,4 @@
-unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+unitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 prefixdir = get_option('prefix')
 bindir = join_paths(prefixdir, get_option('bindir'))
 


### PR DESCRIPTION
fixes #58
