### PR TITLE
meson: allow installing systemd service without systemd

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('man', type : 'feature', value : 'auto',
        description : 'build manpage with ronn')
-option('systemd', type : 'feature', value : 'auto',
+option('systemd', type : 'boolean', value : true,
        description :'enable systemd support')

--- a/services/meson.build
+++ b/services/meson.build
@@ -1,4 +1,3 @@
-systemd = dependency('systemd', required: get_option('systemd'))
-if systemd.found()
+if get_option('systemd')
     subdir('systemd')
 endif

--- a/services/systemd/meson.build
+++ b/services/systemd/meson.build
@@ -1,5 +1,5 @@
-unitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 prefixdir = get_option('prefix')
+unitdir = join_paths(prefixdir, get_option('libdir'), 'systemd', 'system')
 bindir = join_paths(prefixdir, get_option('bindir'))
 
 unit_conf = configuration_data()


### PR DESCRIPTION
A vendor may support systemd while not installing it in the build environment. This would cause systemd to not be detected and the service to not be installed.

Changes the logic to be based off of explicitly listing the option instead of automatically detected.