### PR TITLE
Fix silent hangs and unkillable deadlocks when the audio output is wedged

### DIFF
--- a/src/espeak.c
+++ b/src/espeak.c
@@ -321,7 +321,7 @@ static void synth_queue_clear()
 	}
 }
 
-static void reinitialize_espeak(struct synth_t *s)
+static int reinitialize_espeak(struct synth_t *s)
 {
 	int rate;
 
@@ -329,7 +329,7 @@ static void reinitialize_espeak(struct synth_t *s)
 	rate = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 0, NULL, 0);
 	if (rate < 0) {
 		fprintf(stderr, "Unable to initialize espeak.\n");
-		return;
+		return -1;
 	}
 
 	espeak_SetSynthCallback(callback);
@@ -342,7 +342,7 @@ static void reinitialize_espeak(struct synth_t *s)
 	espeak_SetParameter(espeakVOLUME, (s->volume + 1) * volumeMultiplier, 0);
 	espeak_SetParameter(espeakCAPITALS, 0, 0);
 	paused_espeak = 0;
-	return;
+	return 0;
 }
 
 /* Wait for up to a second before retrying an entry which could not be
@@ -372,7 +372,15 @@ static void queue_process_entry(struct synth_t *s)
 	pthread_mutex_unlock(&queue_guard);
 
 	if (current->cmd != CMD_PAUSE && paused_espeak) {
-		reinitialize_espeak(s);
+		if (reinitialize_espeak(s) < 0) {
+			/* Espeak is unavailable, so the entry cannot be processed.
+			 * Calling espeak functions on a terminated engine would
+			 * just fail (or worse).  Leave the entry queued and retry
+			 * after a small pause. */
+			pthread_mutex_lock(&queue_guard);
+			espeak_wait_retry();
+			return;
+		}
 	}
 
 	switch (current->cmd) {

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "espeakup.h"
 
@@ -48,9 +49,30 @@ const int volumeMultiplier = 22;
 volatile int stop_requested = 0;
 int paused_espeak = 1;
 
+/* Wedged-engine detection.  Espeak may legitimately refuse entries for a
+ * while (EE_BUFFER_FULL while a long backlog is being played back), so a
+ * failing entry is normally just retried.  But when entries keep failing
+ * while the synth callback reports no progress at all, the audio output
+ * is most likely wedged (e.g. an ALSA device stuck returning EBUSY).
+ * After ESPEAK_STALL_RETRIES consecutive such retries (about one second
+ * each), restart the engine; after ESPEAK_MAX_RESTARTS restarts without
+ * the engine having been healthy for ESPEAK_HEALTHY_SECS in between,
+ * give up and exit, so that the init system can respawn us. */
+#define ESPEAK_STALL_RETRIES 10
+#define ESPEAK_MAX_RESTARTS 3
+#define ESPEAK_HEALTHY_SECS 60
+
+/* Set by the synth callback whenever espeak makes synthesis progress;
+ * used to tell a merely backlogged engine from a wedged one. */
+static volatile int synth_progressed = 0;
+static int stalled_retries = 0;
+static int restart_attempts = 0;
+static struct timespec last_restart;
+
 static int callback(short *wav, int numsamples, espeak_EVENT *events)
 {
 	int i;
+	synth_progressed = 1;
 	for (i = 0; events[i].type != espeakEVENT_LIST_TERMINATED; i++) {
 		if (events[i].type == espeakEVENT_MARK) {
 			int mark = atoi(events[i].id.name);
@@ -358,6 +380,50 @@ static void espeak_wait_retry(void)
 	pthread_cond_timedwait(&wake_stop, &queue_guard, &timeout);
 }
 
+/* Handle an entry which could not be processed.  Called and returns
+ * with queue_guard held.
+ * Normally just back off before the retry, but watch out for a wedged
+ * engine: if entries keep failing while the synth callback shows no
+ * progress at all, restart the engine, and if restarting does not help
+ * either, exit so that the init system respawns us in a clean state. */
+static void espeak_handle_failure(struct synth_t *s)
+{
+	if (synth_progressed) {
+		/* Espeak is making progress, it is merely backlogged. */
+		synth_progressed = 0;
+		stalled_retries = 0;
+	} else if (++stalled_retries >= ESPEAK_STALL_RETRIES) {
+		stalled_retries = 0;
+		if (++restart_attempts > ESPEAK_MAX_RESTARTS) {
+			fprintf(stderr, "espeakup: espeak keeps failing without "
+			        "making progress and restarting it did not help, "
+			        "aborting\n");
+			/* Use _exit because exit could hang in library destructors
+			 * while the audio device is wedged. */
+			_exit(3);
+		}
+		fprintf(stderr, "espeakup: espeak has been failing without "
+		        "making progress for %d seconds, restarting it\n",
+		        ESPEAK_STALL_RETRIES);
+		/* Call into espeak with queue_guard released: these calls can
+		 * take time, or block on a wedged audio device.  If they do
+		 * block forever, the stop-acknowledgement timeout in the
+		 * softsynth thread is our last resort. */
+		pthread_mutex_unlock(&queue_guard);
+		if (!paused_espeak) {
+			espeak_Cancel();
+			espeak_Terminate();
+			paused_espeak = 1;
+		}
+		reinitialize_espeak(s);
+		clock_gettime(CLOCK_MONOTONIC, &last_restart);
+		pthread_mutex_lock(&queue_guard);
+		return;
+	}
+
+	espeak_wait_retry();
+}
+
 static struct espeak_entry_t *current = NULL;
 static void queue_process_entry(struct synth_t *s)
 {
@@ -378,7 +444,7 @@ static void queue_process_entry(struct synth_t *s)
 			 * just fail (or worse).  Leave the entry queued and retry
 			 * after a small pause. */
 			pthread_mutex_lock(&queue_guard);
-			espeak_wait_retry();
+			espeak_handle_failure(s);
 			return;
 		}
 	}
@@ -440,6 +506,18 @@ static void queue_process_entry(struct synth_t *s)
 		assert(unqueued == current);
 		free_espeak_entry(current);
 		current = NULL;
+		stalled_retries = 0;
+		if (restart_attempts) {
+			/* Forget about past restarts once the engine has been
+			 * healthy for a while.  Entries can spuriously succeed
+			 * right after a restart while the audio output is still
+			 * wedged (espeak's internal queue is empty again), so a
+			 * quick success must not reset the counter. */
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			if (now.tv_sec - last_restart.tv_sec >= ESPEAK_HEALTHY_SECS)
+				restart_attempts = 0;
+		}
 	} else {
 		if (error != EE_BUFFER_FULL)
 			fprintf(stderr, "espeak error: %d\n", error);
@@ -447,7 +525,7 @@ static void queue_process_entry(struct synth_t *s)
 		 * little break before that, whatever the error: previously only
 		 * EE_BUFFER_FULL throttled, and any other persistent error made
 		 * us retry the same entry in a tight loop, burning a whole CPU. */
-		espeak_wait_retry();
+		espeak_handle_failure(s);
 	}
 }
 

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -21,6 +21,7 @@
 #include <alsa/asoundlib.h>
 #include <assert.h>
 #include <math.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,8 +64,9 @@ int paused_espeak = 1;
 #define ESPEAK_HEALTHY_SECS 60
 
 /* Set by the synth callback whenever espeak makes synthesis progress;
- * used to tell a merely backlogged engine from a wedged one. */
-static volatile int synth_progressed = 0;
+ * used to tell a merely backlogged engine from a wedged one.  The
+ * callback runs in espeak's own thread, so the flag is atomic. */
+static atomic_int synth_progressed = 0;
 static int stalled_retries = 0;
 static int restart_attempts = 0;
 static struct timespec last_restart;
@@ -72,7 +74,7 @@ static struct timespec last_restart;
 static int callback(short *wav, int numsamples, espeak_EVENT *events)
 {
 	int i;
-	synth_progressed = 1;
+	atomic_store(&synth_progressed, 1);
 	for (i = 0; events[i].type != espeakEVENT_LIST_TERMINATED; i++) {
 		if (events[i].type == espeakEVENT_MARK) {
 			int mark = atoi(events[i].id.name);
@@ -388,9 +390,8 @@ static void espeak_wait_retry(void)
  * either, exit so that the init system respawns us in a clean state. */
 static void espeak_handle_failure(struct synth_t *s)
 {
-	if (synth_progressed) {
+	if (atomic_exchange(&synth_progressed, 0)) {
 		/* Espeak is making progress, it is merely backlogged. */
-		synth_progressed = 0;
 		stalled_retries = 0;
 	} else if (++stalled_retries >= ESPEAK_STALL_RETRIES) {
 		stalled_retries = 0;

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -492,7 +492,16 @@ void *espeak_thread(void *arg)
 
 		if (stop_requested) {
 			current = NULL;
+			/* Call into espeak with queue_guard released: espeak_Cancel
+			 * can take time, or even block indefinitely when the audio
+			 * output is wedged, and holding the lock here would prevent
+			 * the other threads from ever making progress again.  The
+			 * queue cannot change concurrently: the only producer (the
+			 * softsynth thread) is blocked waiting for stop_acknowledged
+			 * as long as stop_requested is set. */
+			pthread_mutex_unlock(&queue_guard);
 			stop_speech();
+			pthread_mutex_lock(&queue_guard);
 			synth_queue_clear();
 			stop_requested = 0;
 			pthread_cond_signal(&stop_acknowledged);

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -375,7 +375,7 @@ static void espeak_wait_retry(void)
 {
 	struct timespec timeout;
 
-	clock_gettime(CLOCK_REALTIME, &timeout);
+	clock_gettime(CLOCK_MONOTONIC, &timeout);
 	timeout.tv_sec++;
 	pthread_cond_timedwait(&wake_stop, &queue_guard, &timeout);
 }

--- a/src/espeak.c
+++ b/src/espeak.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "espeakup.h"
 
@@ -344,6 +345,19 @@ static void reinitialize_espeak(struct synth_t *s)
 	return;
 }
 
+/* Wait for up to a second before retrying an entry which could not be
+ * processed, so that we do not busy-loop on a persistent error.  Called
+ * and returns with queue_guard held.  Wakes up immediately if a stop is
+ * requested. */
+static void espeak_wait_retry(void)
+{
+	struct timespec timeout;
+
+	clock_gettime(CLOCK_REALTIME, &timeout);
+	timeout.tv_sec++;
+	pthread_cond_timedwait(&wake_stop, &queue_guard, &timeout);
+}
+
 static struct espeak_entry_t *current = NULL;
 static void queue_process_entry(struct synth_t *s)
 {
@@ -419,17 +433,13 @@ static void queue_process_entry(struct synth_t *s)
 		free_espeak_entry(current);
 		current = NULL;
 	} else {
-		if (error == EE_BUFFER_FULL)
-		{
-			/* Give speak a little break before retrying */
-			struct timespec timeout;
-			clock_gettime(CLOCK_REALTIME, &timeout);
-			timeout.tv_sec++;
-			/* But wake up immediately if we have to stop */
-			pthread_cond_timedwait(&wake_stop, &queue_guard, &timeout);
-		}
-		else
+		if (error != EE_BUFFER_FULL)
 			fprintf(stderr, "espeak error: %d\n", error);
+		/* The entry stays queued and will be retried.  Give espeak a
+		 * little break before that, whatever the error: previously only
+		 * EE_BUFFER_FULL throttled, and any other persistent error made
+		 * us retry the same entry in a tight loop, burning a whole CPU. */
+		espeak_wait_retry();
 	}
 }
 

--- a/src/espeakup.c
+++ b/src/espeakup.c
@@ -41,8 +41,8 @@ volatile int should_run = 1;
 espeak_AUDIO_OUTPUT audio_mode;
 
 pthread_cond_t runner_awake = PTHREAD_COND_INITIALIZER;
-pthread_cond_t wake_stop = PTHREAD_COND_INITIALIZER;
-/* Initialized in main: uses the monotonic clock for timed waits. */
+/* Initialized in main: use the monotonic clock for timed waits. */
+pthread_cond_t wake_stop;
 pthread_cond_t stop_acknowledged;
 pthread_mutex_t queue_guard = PTHREAD_MUTEX_INITIALIZER;
 
@@ -157,6 +157,7 @@ int main(int argc, char **argv)
 	 * too early or far too late. */
 	pthread_condattr_init(&monotonic_attr);
 	pthread_condattr_setclock(&monotonic_attr, CLOCK_MONOTONIC);
+	pthread_cond_init(&wake_stop, &monotonic_attr);
 	pthread_cond_init(&stop_acknowledged, &monotonic_attr);
 	pthread_condattr_destroy(&monotonic_attr);
 

--- a/src/espeakup.c
+++ b/src/espeakup.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/file.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "espeakup.h"
@@ -41,7 +42,8 @@ espeak_AUDIO_OUTPUT audio_mode;
 
 pthread_cond_t runner_awake = PTHREAD_COND_INITIALIZER;
 pthread_cond_t wake_stop = PTHREAD_COND_INITIALIZER;
-pthread_cond_t stop_acknowledged = PTHREAD_COND_INITIALIZER;
+/* Initialized in main: uses the monotonic clock for timed waits. */
+pthread_cond_t stop_acknowledged;
 pthread_mutex_t queue_guard = PTHREAD_MUTEX_INITIALIZER;
 
 int espeakup_start_daemon(void)
@@ -147,6 +149,17 @@ int main(int argc, char **argv)
 	struct synth_t s = {
 		.voice = "",
 	};
+	pthread_condattr_t monotonic_attr;
+
+	/* Condition variables used with pthread_cond_timedwait must use the
+	 * monotonic clock, so that wall-clock adjustments (NTP, an
+	 * installer setting the system time) cannot make the timeouts fire
+	 * too early or far too late. */
+	pthread_condattr_init(&monotonic_attr);
+	pthread_condattr_setclock(&monotonic_attr, CLOCK_MONOTONIC);
+	pthread_cond_init(&stop_acknowledged, &monotonic_attr);
+	pthread_condattr_destroy(&monotonic_attr);
+
 	synth_queue = new_queue();
 
 	if (!synth_queue) {

--- a/src/signal.c
+++ b/src/signal.c
@@ -58,6 +58,14 @@ void *signal_thread(void *arg)
 		case SIGTERM:
 			pthread_mutex_lock(&queue_guard);
 			should_run = 0;
+			/* Wake up any thread waiting on a condition variable so
+			 * that it notices the shutdown request: the softsynth
+			 * thread may be waiting for a stop acknowledgement, and
+			 * the espeak thread may be waiting for work or throttling
+			 * before a retry. */
+			pthread_cond_broadcast(&runner_awake);
+			pthread_cond_broadcast(&wake_stop);
+			pthread_cond_broadcast(&stop_acknowledged);
 			pthread_mutex_unlock(&queue_guard);
 			break;
 		default:

--- a/src/softsynth.c
+++ b/src/softsynth.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/select.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "espeakup.h"
@@ -223,15 +224,37 @@ static void process_buffer_acsint(struct synth_t *s, char *buf, ssize_t length)
 	}
 }
 
+/* How long to wait for the espeak thread to acknowledge a stop request
+ * before concluding that espeak is wedged beyond in-process recovery. */
+static const int stopAckTimeout = 10;
+
 static void request_espeak_stop(void)
 {
+	struct timespec timeout;
+	int err = 0;
+
 	pthread_mutex_lock(&queue_guard);
 	stop_requested = 1;
 	pthread_cond_signal(&runner_awake);     // Wake runner, if necessary.
 	pthread_cond_signal(&wake_stop);        // Wake runner, if necessary.
-	while (should_run && stop_requested)
+	clock_gettime(CLOCK_REALTIME, &timeout);
+	timeout.tv_sec += stopAckTimeout;
+	while (should_run && stop_requested && err != ETIMEDOUT)
 		// wait for acknowledgement.
-		pthread_cond_wait(&stop_acknowledged, &queue_guard);
+		err = pthread_cond_timedwait(&stop_acknowledged, &queue_guard,
+		                             &timeout);
+	if (should_run && stop_requested) {
+		/* The espeak thread is stuck in a call into espeak, most likely
+		 * on a wedged audio device.  There is no way to recover from
+		 * within the process: exit so that the init system can respawn
+		 * us in a clean state, rather than staying silent, ignoring
+		 * SIGTERM, and stalling the whole console by not draining
+		 * /dev/softsynth anymore.  Use _exit because exit could hang in
+		 * library destructors while the audio device is wedged. */
+		fprintf(stderr, "espeakup: espeak did not acknowledge a stop "
+		        "request within %d seconds, aborting\n", stopAckTimeout);
+		_exit(3);
+	}
 	pthread_mutex_unlock(&queue_guard);
 }
 

--- a/src/softsynth.c
+++ b/src/softsynth.c
@@ -237,7 +237,7 @@ static void request_espeak_stop(void)
 	stop_requested = 1;
 	pthread_cond_signal(&runner_awake);     // Wake runner, if necessary.
 	pthread_cond_signal(&wake_stop);        // Wake runner, if necessary.
-	clock_gettime(CLOCK_REALTIME, &timeout);
+	clock_gettime(CLOCK_MONOTONIC, &timeout);
 	timeout.tv_sec += stopAckTimeout;
 	while (should_run && stop_requested && err != ETIMEDOUT)
 		// wait for acknowledgement.


### PR DESCRIPTION
This addresses the freezes reported in #45 and #62: espeakup going permanently silent, ignoring SIGINT/SIGTERM (only SIGKILL works), and even stalling console output.

## Root cause analysis

The trigger lives below espeakup (an ALSA device that wedges or gets stuck returning `EBUSY` — the `error: Device or resource busy` messages in #62 come from libespeak-ng/pcaudiolib, printed by `dispatch_audio()`), but espeakup's lock topology amplified a stuck audio call into a full process deadlock:

1. espeak-ng's internal *say* thread blocks inside an ALSA call (`snd_pcm_writei`/`snd_pcm_drain` on a wedged device) and never checks its stop flag again.
2. On the next flush (`0x18`), the softsynth thread calls `request_espeak_stop()` and waits for `stop_acknowledged` **with no timeout**.
3. The espeak thread calls `stop_speech()` → `espeak_Cancel()` **while holding `queue_guard`**; `espeak_Cancel()` waits forever for the say thread → the mutex is held forever.
4. SIGINT/SIGTERM: the signal thread blocks on `pthread_mutex_lock(&queue_guard)` → signals appear ignored, only SIGKILL works (the "even systemd hangs restarting it" in #62).
5. The softsynth thread never returns to reading `/dev/softsynth` → speakup's kernel buffer fills → console output stalls. That matches the "blocks dmesg output after a couple of pages" observation in #45 exactly.

## What this PR does

Each commit is self-contained, in increasing order of ambition:

- **espeak: do not call `espeak_Cancel()` while holding `queue_guard`** — breaks the deadlock at step 3; SIGTERM works again even when espeak-ng is stuck. Safe because the only queue producer is blocked waiting for the acknowledgement while `stop_requested` is set.
- **signal: wake all condition-variable waiters on shutdown** — `should_run = 0` now broadcasts all three condvars so threads parked in any wait re-check their predicate.
- **softsynth: bound the wait for espeak to acknowledge a stop request** — wait at most 10 s (a normal cancel takes milliseconds), then print a clear message and `_exit(3)` so the init system respawns espeakup (our systemd unit already has `Restart=always`). A short restart beats an unkillable silent daemon, and was explicitly requested in #62.
- **espeak: back off before retrying after any espeak error** — previously only `EE_BUFFER_FULL` throttled; any other persistent error busy-looped at 100% CPU.
- **espeak: do not call espeak functions after a failed reinitialization** — resuming from `CMD_PAUSE` ignored `espeak_Initialize()` failure and kept calling `espeak_Synth()` on a terminated engine.
- **espeak: detect a wedged engine, restart it, and eventually give up** — `EE_BUFFER_FULL` is normal while a long backlog plays, so persistent failure alone is not a wedge signal. Progress is tracked via the synth callback (invoked for every synthesized chunk, paced by playback): ~10 s of failures with zero callback activity → in-process engine restart (`espeak_Cancel` + `espeak_Terminate` + reinitialize); 3 restarts without a healthy minute in between → exit for a clean respawn. Quick successes right after a restart deliberately do not count as healthy, since espeak's freshly emptied internal queue accepts entries even while the device is still wedged.

The recovery is layered on purpose: if the in-process restart itself blocks on the wedged device, the stop-acknowledgement timeout still terminates the process on the next flush. All bail-out paths use `_exit()`, since plain `exit()` could hang in library destructors while the device is wedged.

Known leftover (intentional): on SIGTERM with a wedged engine, `main()` can still block in `pthread_join()` of the espeak thread; systemd's stop timeout escalates to SIGKILL. The point of this PR is that espeakup no longer hangs *silently and unkillably* in normal operation.

## Testing

For those affected by #45/#62: please run this branch in the foreground (`espeakup --debug`, or via the unit with `StandardError=journal`) and report:
- whether speech recovers after the `espeakup: espeak has been failing without making progress for 10 seconds, restarting it` message,
- whether, in the worst case, espeakup now exits (and gets respawned by systemd) instead of hanging until `killall -9`,
- any `espeakup: espeak did not acknowledge a stop request within 10 seconds, aborting` messages, which indicate espeak-ng was stuck inside ALSA — useful evidence for the driver-side investigation.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.