### PR TITLE
services: add fallback systemd unitdir if systemd is not available

### DIFF
--- a/services/meson.build
+++ b/services/meson.build
@@ -1,4 +1,4 @@
-systemd = dependency('systemd', required: get_option('systemd'))
-if systemd.found()
+systemd = dependency('systemd')
+if (systemd.found() and get_option('systemd').allowed()) or get_option('systemd').enabled()
     subdir('systemd')
 endif

--- a/services/systemd/meson.build
+++ b/services/systemd/meson.build
@@ -1,4 +1,8 @@
-unitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+if systemd.found()
+  unitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+else
+  unitdir = join_paths(prefixdir, get_option('libdir'), 'systemd', 'system')
+endif
 prefixdir = get_option('prefix')
 bindir = join_paths(prefixdir, get_option('bindir'))
 


### PR DESCRIPTION
Allows building the service files without a systemd dependency by defining a default systemd user unit directory.

Relevant in Alpine, where we can package the service files in a subpackage without having systemd in Alpine.

Addresses feedback of https://github.com/linux-speakup/espeakup/pull/64, therefore superseeds it.